### PR TITLE
infra: Add steps to get and include Qermit docs in prototype

### DIFF
--- a/.github/workflows/deploy_site.yml
+++ b/.github/workflows/deploy_site.yml
@@ -39,6 +39,22 @@ jobs:
         run: rm ${{ env.DOCS_DIR }}/lambeq/index.html
       - name: (Lambeq) Extract docs tarball into correct place
         run: tar -xzf lambeq-docs-${{ steps.latest-lambeq.outputs.release }}.tar.gz -C ${{ env.DOCS_DIR }}/lambeq
+      - name: (Qermit) Get version of latest release
+        id: latest-qermit
+        run: echo "release=$(gh release view -R isobelhooper/Qermit --json tagName --jq .tagName)" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: (Qermit) Get tarball from latest release
+        uses: dsaltares/fetch-gh-release-asset@1.1.2
+        with:
+          repo: 'isobelhooper/Qermit'
+          version: 'tags/${{ steps.latest-qermit.outputs.release }}'
+          file: 'qermit-docs-${{ steps.latest-qermit.outputs.release }}.tar.gz'
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: (Qermit) Remove placeholder index file
+        run: rm ${{ env.DOCS_DIR }}/qermit/index.html
+      - name: (Qermit) Extract docs tarball into correct place
+        run: tar -xzf qermit-docs-${{ steps.latest-lambeq.outputs.release }}.tar.gz -C ${{ env.DOCS_DIR }}/qermit
       - name: Upload Github Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Right now I've just copy-pasted the steps we did for Lambeq and changed them to refer to isobelhooper/Qermit and files with "qermit" in instead.

I don't think it's feasible to maintain these as copy-pasted for everything, but I'll need to see what I can do with matrix: as that might not work exactly how we'd like.