### PR TITLE
Add noindex robots meta tag while developing site

### DIFF
--- a/base_site/index.html
+++ b/base_site/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <head>
   <meta charset="utf-8">
+  <meta name="robots" content="noindex">
   <title>Quantinuum Documentation</title>
   <link href="_static/styles/theme.css?digest=8d27b9dea8ad943066ae" rel="stylesheet">
   <link href="_static/styles/bootstrap.css?digest=8d27b9dea8ad943066ae" rel="stylesheet">


### PR DESCRIPTION
This should be removed once this is actually live, but for now I think we don't want to index this site.

(possibly it'd make sense to include this in our test theme as well, but that's maybe less important)